### PR TITLE
To avoid parallelMutate error

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -10,6 +10,8 @@ export JAVA_OPTIONS=${JAVA_OPTIONS:- -Xms512m -Xmx2048m}
 
 export JAVA_OPTIONS="$JAVA_OPTIONS -javaagent:/opt/dynamodb/$SERVER_DIR/lib/jamm-0.3.0.jar"
 
+echo  "storage.dynamodb.native-locking=false" >> ${PROPS}
+
 echo "Proceeding with JAVA_OPTIONS=$JAVA_OPTIONS"
 
 sed -i.bckp 's#host: .*#host: '$GREMLIN_HOST'#' ${GREMLIN_CONF}


### PR DESCRIPTION
```storage.dynamodb.native-locking=false``` is added to enable the dynamodb locks which will remove parallelMutate error. This has been checked in local build and corresponding config file. The content of config file are in http://pastebin.test.redhat.com/486363 .

Thanks,

Saket