### PR TITLE
Phony change to rebuild image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,3 @@ get-image-name:
 
 get-image-repository:
 	@echo $(REPOSITORY)
-


### PR DESCRIPTION
since the [latest devtools-gremlin-docker-f8a-build-master failed](https://ci.centos.org/job/devtools-gremlin-docker-f8a-build-master/7/console) due to [e2e test](https://ci.centos.org/job/devtools-f8a-master-deploy-e2e-test/529/console)