### PR TITLE
Introduce RHEL based image

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,47 @@
+# base image source https://github.com/rhdt/EL-Dockerfiles/blob/master/base/jboss-jdk-8/Dockerfile
+
+FROM prod.registry.devshift.net/osio-prod/base/jboss-jdk-8:latest
+
+EXPOSE 8182
+
+RUN curl -o /opt/titan-1.1.0-SNAPSHOT-hadoop2.zip https://s3.amazonaws.com/gremlin-tarballs/titan-1.1.0-SNAPSHOT-hadoop2.zip
+RUN curl -O https://s3.amazonaws.com/gremlin-tarballs/titan-all.tgz &&\
+    tar xzf titan-all.tgz
+
+# Prep, build and install DynamoDB storage backend driver with support for titan, and install Gremlin server
+RUN git clone https://github.com/awslabs/dynamodb-titan-storage-backend.git /opt/dynamodb/dynamodb-titan-storage-backend/ &&\
+    cd /opt/dynamodb/dynamodb-titan-storage-backend/ &&\
+    git checkout d1a59624dcef796b835e7ffb41f0a3f007008d63 -b "last-working" &&\
+    curl https://gist.githubusercontent.com/pluradj/d56c1948f4665ee7fb1bc35daeba4f92/raw/be5f639a64c8d6ac196c59eb7e6d1a1903015b17/dynamo-titan11-tp323.patch | git apply -v --index &&\
+    mvn install
+
+
+RUN cd /opt/dynamodb/dynamodb-titan-storage-backend/ &&\
+    sed -i 's#TITAN_VANILLA_SERVER_ZIP=.*#TITAN_VANILLA_SERVER_ZIP=/opt/titan-1.1.0-SNAPSHOT-hadoop2.zip#' src/test/resources/install-gremlin-server.sh &&\
+    src/test/resources/install-gremlin-server.sh
+
+WORKDIR /opt/dynamodb/
+
+# Install Gremlin Python
+RUN mkdir -p /root/.m2/repository/org/slf4j/slf4j-api/1.7.21/ &&\
+    cd dynamodb-titan-storage-backend/server/dynamodb-titan100-storage-backend-1.0.0-hadoop1 &&\
+    curl -o /root/.m2/repository/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar http://central.maven.org/maven2/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar &&\
+    bin/gremlin-server.sh -i org.apache.tinkerpop gremlin-python 3.2.3
+
+ADD scripts/entrypoint.sh /bin/entrypoint.sh
+
+RUN chmod +x /bin/entrypoint.sh &&\
+    chgrp -R 0 /opt/dynamodb/ &&\
+    chmod -R g+rw /opt/dynamodb/ &&\
+    find /opt/dynamodb/ -type d -exec chmod g+x {} +
+
+ADD scripts/entrypoint-local.sh /bin/entrypoint-local.sh
+RUN chmod +x /bin/entrypoint-local.sh
+
+COPY scripts/post-hook.sh /bin/
+
+# We have already built everything, so remove the local repo now
+RUN rm -rf /root/.m2 /titan-all.tgz /opt/titan-1.1.0-SNAPSHOT-hadoop2.zip /opt/dynamodb/dynamodb-titan-storage-backend/server/dynamodb-titan100-storage-backend-1.0.0-hadoop1.zip
+
+ENTRYPOINT ["/bin/entrypoint.sh"]
+

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ifeq ($(TARGET),rhel)
   REGISTRY := push.registry.devshift.net/osio-prod
 else
   DOCKERFILE := Dockerfile
-  REGISTRY := registry.devshift.net
+  REGISTRY := push.registry.devshift.net
 endif
 
 REPOSITORY?=bayesian/gremlin

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
-REGISTRY?=registry.devshift.net
+ifeq ($(TARGET),rhel)
+  DOCKERFILE := Dockerfile.rhel
+  REGISTRY := push.registry.devshift.net/osio-prod
+else
+  DOCKERFILE := Dockerfile
+  REGISTRY := registry.devshift.net
+endif
+
 REPOSITORY?=bayesian/gremlin
 DEFAULT_TAG=latest
 
@@ -7,13 +14,16 @@ DEFAULT_TAG=latest
 all: fast-docker-build
 
 docker-build:
-	docker build --no-cache -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) .
+	docker build --no-cache -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) -f $(DOCKERFILE) .
 
 fast-docker-build:
-	docker build -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) .
+	docker build -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) -f $(DOCKERFILE) .
 
 get-image-name:
 	@echo $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG)
 
 get-image-repository:
 	@echo $(REPOSITORY)
+
+get-push-registry:
+	@echo $(REGISTRY)

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -17,6 +17,13 @@ prep() {
 }
 
 build_image() {
+    # login before build to be able to pull RHEL parent image 
+    if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
+        docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${push_registry}
+    else
+        echo "Could not login, missing credentials for the registry"
+        exit 1
+    fi
     make docker-build
 }
 
@@ -36,14 +43,6 @@ push_image() {
     image_repository=$(make get-image-repository)
     short_commit=$(git rev-parse --short=7 HEAD)
     push_registry=$(make get-push-registry)
-
-    # login first
-    if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
-        docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${push_registry}
-    else
-        echo "Could not login, missing credentials for the registry"
-        exit 1
-    fi
 
     if [ -n "${ghprbPullId}" ]; then
         # PR build

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -35,7 +35,7 @@ push_image() {
     image_name=$(make get-image-name)
     image_repository=$(make get-image-repository)
     short_commit=$(git rev-parse --short=7 HEAD)
-    push_registry="push.registry.devshift.net"
+    push_registry=$(make get-push-registry)
 
     # login first
     if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -17,6 +17,8 @@ prep() {
 }
 
 build_image() {
+    local push_registry
+    push_registry=$(make get-push-registry)
     # login before build to be able to pull RHEL parent image 
     if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
         docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${push_registry}


### PR DESCRIPTION
Enable build on RHEL if TARGET=rhel.

The cico environment will continue to build the CentOS based container and in a second step it will build and push a RHEL based container.

cc: @jmelis @msrb @miteshvp