### PR TITLE
Revert "Add jre runtime flag to enable cgroups memory limit (#62)"

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -10,7 +10,7 @@ STORAGE_BACKEND=com.amazon.janusgraph.diskstorage.dynamodb.DynamoDBStoreManager
 USE_TITAN_IDS=true
 TITAN_IDS=titan_ids
 
-export JAVA_OPTIONS=${JAVA_OPTIONS:- -XX:+PrintFlagsFinal -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap}
+export JAVA_OPTIONS=${JAVA_OPTIONS:- -Xms512m -Xmx1400m}
 
 export JAVA_OPTIONS="$JAVA_OPTIONS -javaagent:/opt/dynamodb/$SERVER_DIR/lib/jamm-0.3.0.jar"
 


### PR DESCRIPTION
This reverts commit c46b23f28f7856bae15bc851865f2bb8324d7196.