### PR TITLE
Add JAVA_OPTIONS as template param

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -71,6 +71,8 @@ objects:
                secretKeyRef:
                  name: aws-dynamodb
                  key: aws_region
+          - name: JAVA_OPTIONS
+            value: ${JAVA_OPTIONS}
           image: "${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${IMAGE_TAG}"
           imagePullPolicy: Always
           name: bayesian-gremlin
@@ -167,4 +169,10 @@ parameters:
   displayName: Query administration region
   required: false
   name: QUERY_ADMINISTRATION_REGION
+  value: ""
+
+- description: JVM Options
+  displayName: JVM Options
+  required: false
+  name: JAVA_OPTIONS
   value: ""


### PR DESCRIPTION
Idea is to override JAVA_OPTIONS from https://github.com/openshiftio/saas-analytics/blob/master/bay-services/gremlin.yaml. It given us a flexibility to use CGroups related JVM settings directly from the deployment templates.