### PR TITLE
Add instance prefix for DynamoDB tables created from JanusGraph

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN mkdir -p ${M2_DIR}/root &&\
     rm -rf ~/.m2/repository &&\
     rm -rf ~/.groovy/grapes &&\
     mkdir -p ${M2_REPO}/org/slf4j/slf4j-api/1.7.21/ &&\
-    curl -o ${M2_REPO}/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar http://central.maven.org/maven2/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar
+    curl -o ${M2_REPO}/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar
     
 # Install Gremlin Python
 RUN cd dynamodb-janusgraph-storage-backend/server/dynamodb-janusgraph-storage-backend-1.1.0 &&\

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -25,7 +25,7 @@ RUN mkdir -p ${M2_DIR}/root &&\
     mkdir -p ${M2_REPO}/repository/org/slf4j/slf4j-api/1.7.21/ &&\
     rm -rf ~/.m2/repository &&\
     rm -rf ~/.groovy/grapes &&\
-    curl -o ${M2_REPO}/repository/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar http://central.maven.org/maven2/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar
+    curl -o ${M2_REPO}/repository/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar
 
 
 # Install Gremlin Python

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -11,8 +11,8 @@ objects:
   kind: Service
   metadata:
     labels:
-      service: bayesian-gremlin-${CHANNELIZER}${QUERY_ADMINISTRATION_REGION}
-    name: bayesian-gremlin-${CHANNELIZER}${QUERY_ADMINISTRATION_REGION}
+      service: bayesian-gremlin-${DYNAMODB_INSTANCE_PREFIX}${CHANNELIZER}${QUERY_ADMINISTRATION_REGION}
+    name: bayesian-gremlin-${DYNAMODB_INSTANCE_PREFIX}${CHANNELIZER}${QUERY_ADMINISTRATION_REGION}
   spec:
     ports:
     - name: "8182"
@@ -20,16 +20,16 @@ objects:
       protocol: TCP
       targetPort: 8182
     selector:
-      service: bayesian-gremlin-${CHANNELIZER}${QUERY_ADMINISTRATION_REGION}
+      service: bayesian-gremlin-${DYNAMODB_INSTANCE_PREFIX}${CHANNELIZER}${QUERY_ADMINISTRATION_REGION}
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
     labels:
-      service: bayesian-gremlin-${CHANNELIZER}${QUERY_ADMINISTRATION_REGION}
-    name: bayesian-gremlin-${CHANNELIZER}${QUERY_ADMINISTRATION_REGION}
+      service: bayesian-gremlin-${DYNAMODB_INSTANCE_PREFIX}${CHANNELIZER}${QUERY_ADMINISTRATION_REGION}
+    name: bayesian-gremlin-${DYNAMODB_INSTANCE_PREFIX}${CHANNELIZER}${QUERY_ADMINISTRATION_REGION}
   spec:
     selector:
-      service: bayesian-gremlin-${CHANNELIZER}${QUERY_ADMINISTRATION_REGION}
+      service: bayesian-gremlin-${DYNAMODB_INSTANCE_PREFIX}${CHANNELIZER}${QUERY_ADMINISTRATION_REGION}
     strategy:
       type: Rolling
       rollingParams:
@@ -41,7 +41,7 @@ objects:
     template:
       metadata:
         labels:
-          service: bayesian-gremlin-${CHANNELIZER}${QUERY_ADMINISTRATION_REGION}
+          service: bayesian-gremlin-${DYNAMODB_INSTANCE_PREFIX}${CHANNELIZER}${QUERY_ADMINISTRATION_REGION}
       spec:
         containers:
         - env:
@@ -54,6 +54,8 @@ objects:
                configMapKeyRef:
                  name: bayesian-config
                  key: dynamodb-prefix
+          - name: DYNAMODB_INSTANCE_PREFIX
+            value: ${DYNAMODB_INSTANCE_PREFIX}
           - name: DYNAMODB_CLIENT_CREDENTIALS_CLASS_NAME
             value: ${DYNAMODB_CLIENT_CREDENTIALS_CLASS_NAME}
           - name: AWS_ACCESS_KEY_ID
@@ -113,6 +115,10 @@ parameters:
   name: DYNAMODB_CLIENT_CREDENTIALS_CLASS_NAME
   required: true
   value: "com.amazonaws.auth.DefaultAWSCredentialsProviderChain"
+- description: Value of the 'storage.dynamodb.prefix' property in dynamodb.properties along with DYNAMODB_PREFIX
+  name: DYNAMODB_INSTANCE_PREFIX
+  required: false
+  value: ""
 - description: Value of the 'storage.dynamodb.client.endpoint' property in dynamodb.properties
   name: DYNAMODB_CLIENT_ENDPOINT
   required: false

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -33,6 +33,10 @@ sed -i.bckp 's#slf4jReporter: .*#slf4jReporter: {enabled: false}, #' ${GREMLIN_C
 sed -i.bckp 's#gangliaReporter: .*#gangliaReporter: {enabled: false}, #' ${GREMLIN_CONF}
 sed -i.bckp 's#graphiteReporter: .*#graphiteReporter: {enabled: false}} #' ${GREMLIN_CONF}
 
+if [ -n "$DYNAMODB_INSTANCE_PREFIX" ]; then
+    DYNAMODB_PREFIX="${DYNAMODB_PREFIX}_${DYNAMODB_INSTANCE_PREFIX}"
+fi
+
 if [ -n "$DYNAMODB_CLIENT_CREDENTIALS_CLASS_NAME" ]; then
     sed -i.bckp 's#storage.dynamodb.client.credentials.class-name=.*#storage.dynamodb.client.credentials.class-name='${DYNAMODB_CLIENT_CREDENTIALS_CLASS_NAME}'#' ${PROPS}
 fi


### PR DESCRIPTION
This change allows to create a gremlin/janusgraph instance backed by a completely new set of DynamoDB tables. 