### PR TITLE
Reading DYNAMODB_PREFIX Key from parameter

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -53,7 +53,7 @@ objects:
             valueFrom:
                configMapKeyRef:
                  name: bayesian-config
-                 key: dynamodb-prefix
+                 key: ${DYNAMODB_PREFIX_KEY}
           - name: DYNAMODB_INSTANCE_PREFIX
             value: ${DYNAMODB_INSTANCE_PREFIX}
           - name: DYNAMODB_CLIENT_CREDENTIALS_CLASS_NAME
@@ -127,6 +127,10 @@ parameters:
   name: DYNAMODB_SECRET_NAME
   required: false
   value: "aws-dynamodb"
+- description: Key of configmap that helps to define prefix for DynamoDB table name. 
+  name: DYNAMODB_PREFIX_KEY
+  required: false
+  value: "dynamodb-prefix"
 - description: Change the channelizer being used to deploy the gremlin server. Set this to "1" for HTTP channelizer, and "0" for WebSocket channelizer. Defaults to "0" i.e. WebSocket.
   name: REST_VALUE
   value: "0"


### PR DESCRIPTION
For osa gremlin service, we are using table name prefix with lower case and with existing setup its failing. So reading DYNAMODB_PREFIX Key from parameter with default value `dynamodb-prefix`, so  **existing service don't need to change anything**,  for osa-gremlin-http service will pass DYNAMODB_PREFIX_KEY value as `osa-dynamodb-prefix` into saas-analytics repo.
