### PR TITLE
fix: Conflict in docker package selection after introduction of latest docker usage in Gremlin

### DIFF
--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -67,6 +67,8 @@ push_image() {
         tag_push ${push_registry}/${image_repository}:${short_commit} ${image_name}
     fi
 
+    # uninstall the latest docker until e2e moves to latest
+    yum -y remove docker docker-ce docker-ce-cli
     echo 'CICO: Image pushed, ready to update deployed app'
 }
 


### PR DESCRIPTION
This component uses latest docker to leverage multi-stage docker build, but the downstream e2e build which is triggered from this reuses the same environment which causes conflict when installing centos7 docker.

The solution is to remove the latest docker after completing the whole process.