### PR TITLE
chore: Enable Gremlin metric print on the console for every minute

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -195,4 +195,4 @@ parameters:
   displayName: Gremlin pool size
   required: false
   name: GREMLIN_POOL
-  value: "0"
+  value: "8"

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -190,3 +190,9 @@ parameters:
   required: false
   name: JAVA_OPTIONS
   value: ""
+
+- description: Gremlin pool size
+  displayName: Gremlin pool size
+  required: false
+  name: GREMLIN_POOL
+  value: "0"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -26,7 +26,7 @@ fi
 
 echo "graph.titan-version=1.1.0-SNAPSHOT" >> ${PROPS}
 
-sed -i.bckp 's#consoleReporter: .*#consoleReporter: {enabled: false}, #' ${GREMLIN_CONF}
+sed -i.bckp 's#consoleReporter: .*#consoleReporter: {enabled: true, interval: 60000}, #' ${GREMLIN_CONF}
 sed -i.bckp 's#csvReporter: .*#csvReporter: {enabled: false}, #' ${GREMLIN_CONF}
 sed -i.bckp 's#jmxReporter: .*#jmxReporter: {enabled: false}, #' ${GREMLIN_CONF}
 sed -i.bckp 's#slf4jReporter: .*#slf4jReporter: {enabled: false}, #' ${GREMLIN_CONF}


### PR DESCRIPTION
Reference: https://tinkerpop.apache.org/docs/current/reference/
Sample print:
```
-- Timers ----------------------------------------------------------------------
org.apache.tinkerpop.gremlin.server.GremlinServer.op.eval
             count = 6
         mean rate = 0.02 calls/second
     1-minute rate = 0.01 calls/second
     5-minute rate = 0.01 calls/second
    15-minute rate = 0.01 calls/second
               min = 10684.11 milliseconds
               max = 98444.63 milliseconds
              mean = 54317.79 milliseconds
            stddev = 46239.17 milliseconds
            median = 54044.93 milliseconds
              75% <= 97078.76 milliseconds
              95% <= 98444.63 milliseconds
              98% <= 98444.63 milliseconds
              99% <= 98444.63 milliseconds
            99.9% <= 98444.63 milliseconds
```