### PR TITLE
chore: deployment controller for restarting pods.

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -80,6 +80,8 @@ objects:
                  key: aws_region
           - name: JAVA_OPTIONS
             value: ${JAVA_OPTIONS}
+          - name: DEPLOYMENT_CONTROLLER
+            value: "true"
           image: "${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${IMAGE_TAG}"
           imagePullPolicy: Always
           name: bayesian-gremlin


### PR DESCRIPTION
# Description

Adding an environment variable which can be used to restart gremlin pods when ingestion accuracy seems to decrease due to memory issues.